### PR TITLE
Add anonymous authentication and reset flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Birrino is a clean, minimalist web application for tracking alcohol consumption.
 - Track alcohol consumption by units
 - Select from predefined drinks with standard volumes and ABV percentages
 - View summaries for evening, day, week, month, and year
-- Multiple user profiles
+- Anonymous, per-device authentication
 - Visual progress indicators
 - Notifications when exceeding recommended limits
 
@@ -17,7 +17,7 @@ Birrino is a clean, minimalist web application for tracking alcohol consumption.
 
 - Node.js 18 or newer
 - npm 9 or newer
-- Supabase account with configured tables
+- Supabase project (apply migrations in `migrations/anonymous_auth.sql`)
 
 ### Installation
 
@@ -51,14 +51,6 @@ Birrino is a clean, minimalist web application for tracking alcohol consumption.
 
 The application uses the following Supabase tables:
 
-### users
-```sql
-create table users (
-  id uuid primary key default gen_random_uuid(),
-  name text not null unique
-);
-```
-
 ### drinks
 ```sql
 create table drinks (
@@ -70,15 +62,23 @@ create table drinks (
 );
 ```
 
+### profiles
+```sql
+create table profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  display_name text not null
+);
+```
+
 ### consumption
 ```sql
 create table consumption (
   id uuid primary key default gen_random_uuid(),
-  user_name text not null,
-  drink_id uuid references drinks(id),
-  quantity int not null check (quantity > 0),
-  units numeric(6,3) not null,
-  timestamp timestamptz default now()
+  drink_id uuid not null,
+  quantity int not null,
+  units numeric not null,
+  timestamp timestamptz default now(),
+  user_id uuid references auth.users(id)
 );
 ```
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import type { Metadata } from "next";
 import { Toaster } from "react-hot-toast";
+import AnonSessionInit from "@/components/AnonSessionInit";
 
 export const metadata: Metadata = {
   title: "5° Birrino | Quanti. Non come o perchè.",
@@ -38,6 +39,7 @@ export default function RootLayout({
         />
       </head>
       <body>
+        <AnonSessionInit />
         <main className="min-h-screen bg-gray-50">
           <div className="container-custom py-8">{children}</div>
           <Toaster

--- a/components/AnonSessionInit.tsx
+++ b/components/AnonSessionInit.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { useAnonSession } from "@/hooks/useAnonSession";
+
+export default function AnonSessionInit() {
+  useAnonSession();
+  return null;
+}

--- a/components/DashboardClient.tsx
+++ b/components/DashboardClient.tsx
@@ -51,13 +51,17 @@ export function DashboardClient({ user }: DashboardClientProps) {
   // ----- Effects ------------------------------------------------------------
   useEffect(() => {
     fetchDrinks();
-  }, [user]);
+  }, []);
 
   async function fetchDrinks() {
+    const { data: sessionData } = await supabase.auth.getSession();
+    const userId = sessionData.session?.user?.id;
+    if (!userId) return;
+
     const { data, error } = await supabase
       .from("consumption")
-      .select("*, drinks(name)") // includes drink name via foreign key (if exists)
-      .eq("user_name", user)
+      .select("*, drinks(name)")
+      .eq("user_id", userId)
       .order("timestamp", { ascending: false });
 
     if (!error && data) {
@@ -346,7 +350,6 @@ export function DashboardClient({ user }: DashboardClientProps) {
       <DrinkPicker
         open={showDrinkPicker}
         onOpenChange={setShowDrinkPicker}
-        userName={user}
         onDrinkAdded={fetchDrinks}
       />
 
@@ -354,7 +357,6 @@ export function DashboardClient({ user }: DashboardClientProps) {
       <DrinkForm
         open={showDrinkForm}
         onOpenChange={setShowDrinkForm}
-        userName={user}
         onDrinkAdded={fetchDrinks}
       />
 

--- a/components/DrinkForm.tsx
+++ b/components/DrinkForm.tsx
@@ -31,14 +31,12 @@ interface Drink {
 interface DrinkFormProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  userName: string;
   onDrinkAdded: () => void;
 }
 
 export function DrinkForm({
   open,
   onOpenChange,
-  userName,
   onDrinkAdded,
 }: DrinkFormProps) {
   const [drinks, setDrinks] = useState<Drink[]>([]);
@@ -90,12 +88,10 @@ export function DrinkForm({
     const units = calculateUnits(drink.volume_ml, drink.abv, quantity);
 
     const { error } = await supabase.from("consumption").insert({
-      user_name: userName,
       drink_id: selectedDrink,
       quantity,
       units,
       timestamp: new Date().toISOString(),
-      user_id: userId, // Aggiungiamo l'ID utente dalla sessione
     });
 
     setLoading(false);

--- a/components/DrinkPicker/DrinkList.tsx
+++ b/components/DrinkPicker/DrinkList.tsx
@@ -13,7 +13,6 @@ interface DrinkListProps {
   drinks: Drink[];
   onDrinkSelect: (drink: Drink) => void;
   onDrinkAdded: () => void;
-  userName: string;
   query: string;
 }
 
@@ -21,11 +20,10 @@ export function DrinkList({
   drinks,
   onDrinkSelect,
   onDrinkAdded,
-  userName,
   query,
 }: DrinkListProps) {
-  const { favorites, toggleFavorite } = useFavorites({ userName });
-  const { addRecent } = useRecents({ userName });
+  const { favorites, toggleFavorite } = useFavorites();
+  const { addRecent } = useRecents();
   const [addingDrink, setAddingDrink] = useState<string | null>(null);
 
   const handleQuickAdd = async (
@@ -42,7 +40,6 @@ export function DrinkList({
     }
 
     const { error } = await supabase.from("consumption").insert({
-      user_name: userName,
       drink_id: drink.id,
       quantity,
       units: drink.units * quantity,

--- a/components/DrinkPicker/DrinkPicker.tsx
+++ b/components/DrinkPicker/DrinkPicker.tsx
@@ -24,21 +24,19 @@ interface DrinkPickerProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onDrinkAdded: () => void;
-  userName: string;
 }
 
 export function DrinkPicker({
   open,
   onOpenChange,
   onDrinkAdded,
-  userName,
 }: DrinkPickerProps) {
   const [query, setQuery] = useState("");
   const [selectedDrink, setSelectedDrink] = useState<Drink | null>(null);
   const [addingDrink, setAddingDrink] = useState<string | null>(null);
   const { drinks, category, setCategory, filtered } = useDrinkPicker();
-  const { favorites } = useFavorites({ userName });
-  const { recents, addRecent } = useRecents({ userName });
+  const { favorites } = useFavorites();
+  const { recents, addRecent } = useRecents();
 
   // Ensure anonymous session
   useEffect(() => {
@@ -85,8 +83,6 @@ export function DrinkPicker({
     const userId = data.session?.user?.id;
 
     const { error } = await supabase.from("consumption").insert({
-      user_name: userName,
-      user_id: userId, // Add the user_id from the session
       drink_id: drink.id,
       quantity: 1,
       units: drink.units * 1,
@@ -235,7 +231,6 @@ export function DrinkPicker({
               onDrinkAdded();
               onOpenChange(false); // Auto-close after quick add
             }}
-            userName={userName}
             query={query}
           />
         </div>
@@ -245,7 +240,6 @@ export function DrinkPicker({
             drink={selectedDrink}
             open={!!selectedDrink}
             onOpenChange={(open: boolean) => !open && setSelectedDrink(null)}
-            userName={userName}
             onDrinkAdded={() => {
               onDrinkAdded();
               setSelectedDrink(null);

--- a/components/DrinkPicker/DrinkQuantitySheet.tsx
+++ b/components/DrinkPicker/DrinkQuantitySheet.tsx
@@ -17,7 +17,6 @@ interface DrinkQuantitySheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onDrinkAdded: () => void;
-  userName: string;
 }
 
 export function DrinkQuantitySheet({
@@ -25,10 +24,9 @@ export function DrinkQuantitySheet({
   open,
   onOpenChange,
   onDrinkAdded,
-  userName,
 }: DrinkQuantitySheetProps) {
   const [quantity, setQuantity] = useState(1);
-  const { addRecent } = useRecents({ userName });
+  const { addRecent } = useRecents();
 
   // Ensure anonymous session
   useEffect(() => {
@@ -48,8 +46,6 @@ export function DrinkQuantitySheet({
     const userId = data.session?.user?.id;
 
     const { error } = await supabase.from("consumption").insert({
-      user_name: userName,
-      user_id: userId, // Add user_id from the session
       drink_id: drink.id,
       quantity,
       units: drink.units * quantity,

--- a/components/DrinkPicker/hooks/useRecents.ts
+++ b/components/DrinkPicker/hooks/useRecents.ts
@@ -1,11 +1,7 @@
 import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabaseClient";
 
-interface RecentsHookProps {
-  userName?: string; // Make this optional
-}
-
-export function useRecents({ userName }: RecentsHookProps = {}) {
+export function useRecents() {
   const [recents, setRecents] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [userId, setUserId] = useState<string | null>(null);
@@ -17,13 +13,11 @@ export function useRecents({ userName }: RecentsHookProps = {}) {
 
       if (data?.session?.user) {
         setUserId(data.session.user.id);
-      } else if (userName) {
-        setUserId(userName);
       }
     }
 
     getUserSession();
-  }, [userName]);
+  }, []);
 
   // Fetch recents from Supabase
   useEffect(() => {

--- a/components/StatsModal.tsx
+++ b/components/StatsModal.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/dialog";
 import { Card, CardContent } from "@/components/ui/card";
 import { motion } from "framer-motion";
+import { resetApp } from "@/lib/resetApp";
 
 interface StatsData {
   dailyUnits: number;
@@ -166,6 +167,12 @@ export function StatsModal({
             Nazionale. Non superare le 14 unità a settimana distribuite su
             almeno 3 giorni
           </p>
+          <button
+            onClick={resetApp}
+            className="mt-3 text-xs text-red-600 underline"
+          >
+            Reset app
+          </button>
         </div>
       </DialogContent>
     </Dialog>

--- a/hooks/useAnonSession.ts
+++ b/hooks/useAnonSession.ts
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { supabase } from "@/lib/supabaseClient";
+
+export function useAnonSession() {
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      if (!data.session) {
+        supabase.auth.signInAnonymously();
+      }
+    });
+  }, []);
+}

--- a/lib/resetApp.ts
+++ b/lib/resetApp.ts
@@ -1,0 +1,13 @@
+import { supabase } from "@/lib/supabaseClient";
+
+export async function resetApp() {
+  const { data } = await supabase.auth.getSession();
+  const userId = data.session?.user?.id;
+  if (!userId) return;
+
+  await supabase.from("consumption").delete().eq("user_id", userId);
+  await supabase.from("profiles").delete().eq("id", userId);
+  await supabase.auth.signOut();
+  localStorage.clear();
+  window.location.href = "/";
+}

--- a/migrations/anonymous_auth.sql
+++ b/migrations/anonymous_auth.sql
@@ -1,0 +1,62 @@
+-- Supabase Anonymous Auth schema setup
+
+-- Profiles table linked to auth.users
+create table if not exists profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  display_name text not null check (length(trim(display_name)) > 0)
+);
+
+-- Consumption table scoped by user_id
+create table if not exists consumption (
+  id uuid primary key default gen_random_uuid(),
+  drink_id uuid not null,
+  quantity integer not null,
+  units numeric not null,
+  timestamp timestamptz not null default now(),
+  user_id uuid references auth.users(id) on delete cascade
+);
+
+-- Enable Row Level Security
+alter table profiles enable row level security;
+alter table consumption enable row level security;
+
+-- RLS policies for profiles
+create policy profiles_select on profiles
+  for select using (auth.uid() = id);
+
+create policy profiles_insert on profiles
+  for insert with check (auth.uid() = id);
+
+create policy profiles_update on profiles
+  for update using (auth.uid() = id) with check (auth.uid() = id);
+
+create policy profiles_delete on profiles
+  for delete using (auth.uid() = id);
+
+-- RLS policies for consumption
+create policy consumption_select on consumption
+  for select using (auth.uid() = user_id);
+
+create policy consumption_insert on consumption
+  for insert with check (user_id is null or user_id = auth.uid());
+
+create policy consumption_update on consumption
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+create policy consumption_delete on consumption
+  for delete using (auth.uid() = user_id);
+
+-- Trigger to auto-fill user_id
+create or replace function set_user_id()
+returns trigger language plpgsql as $$
+begin
+  if new.user_id is null then
+    new.user_id := auth.uid();
+  end if;
+  return new;
+end;
+$$;
+
+create trigger consumption_set_user_id
+before insert on consumption
+for each row execute procedure set_user_id();


### PR DESCRIPTION
## Summary
- create anonymous auth migration with RLS policies and trigger
- add hook to initialise anonymous sessions
- auto sign in from layout
- add reset app helper and button
- update drink components to rely on user_id only
- document new schema in README

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6840875097e083229ae40a3ebbac7321