### PR TITLE
Fix dashboard auth and recents policies

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,22 +3,35 @@
 import { DashboardClient } from "@/components/DashboardClient";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { supabase } from "@/lib/supabaseClient";
+import { useAnonSession } from "@/hooks/useAnonSession";
 
 export default function Dashboard() {
+  useAnonSession();
   const [userName, setUserName] = useState<string | null>(null);
   const router = useRouter();
 
   useEffect(() => {
-    // Get the user name from localStorage
-    const storedUserName = localStorage.getItem("currentUserName");
+    const loadProfile = async () => {
+      const { data: sessionData } = await supabase.auth.getSession();
+      const userId = sessionData.session?.user?.id;
+      if (!userId) {
+        router.push("/");
+        return;
+      }
+      const { data, error } = await supabase
+        .from("profiles")
+        .select("display_name")
+        .eq("id", userId)
+        .single();
+      if (error || !data) {
+        router.push("/");
+        return;
+      }
+      setUserName(data.display_name);
+    };
 
-    if (!storedUserName) {
-      // Redirect to home if no user is selected
-      router.push("/");
-      return;
-    }
-
-    setUserName(storedUserName);
+    loadProfile();
   }, [router]);
 
   if (!userName) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,6 @@
 import "./globals.css";
 import type { Metadata } from "next";
 import { Toaster } from "react-hot-toast";
-import { Inter } from "next/font/google";
-
-const inter = Inter({
-  subsets: ["latin"],
-  weight: ["300", "400", "500", "600", "700"],
-  display: "swap",
-});
 
 export const metadata: Metadata = {
   title: "5° Birrino | Quanti. Non come o perchè.",
@@ -29,12 +22,16 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="it" className={inter.className}>
+    <html lang="it">
       <head>
         <meta name="apple-mobile-web-app-title" content="5° Birrino" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="theme-color" content="#ffffff" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=optional"
+        />
         <link rel="icon" href="/favicon/favicon.ico" sizes="any" />
         <link rel="icon" href="/favicon/icon1.png" type="image/png" />
         <link rel="apple-touch-icon" href="/favicon/apple-icon.png" />

--- a/components/ConsumptionInsertTest.tsx
+++ b/components/ConsumptionInsertTest.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { supabase } from "@/lib/supabaseClient";
+import { useAnonSession } from "@/hooks/useAnonSession";
 import { User } from "@supabase/supabase-js";
 
 interface ConsumptionRecord {
@@ -14,6 +15,7 @@ interface ConsumptionRecord {
 }
 
 export default function ConsumptionInsertTest() {
+  useAnonSession();
   const [status, setStatus] = useState<string>("");
   const [sessionInfo, setSessionInfo] = useState<User | null>(null);
   const [insertResult, setInsertResult] = useState<ConsumptionRecord[] | null>(
@@ -25,22 +27,13 @@ export default function ConsumptionInsertTest() {
       data: { session },
     } = await supabase.auth.getSession();
     if (!session) {
-      setStatus("No session found. Creating anonymous session...");
-      const { error } = await supabase.auth.signInAnonymously();
-      if (error) {
-        console.error("Failed to sign in anonymously", error);
-        setStatus(`Error signing in: ${error.message}`);
-        throw error;
-      }
-      setStatus("Anonymous session created successfully");
-    } else {
-      setStatus("Session already exists");
+      setStatus("No session found. Please refresh and try again.");
+      return null;
     }
 
-    // Get and display current session
-    const { data } = await supabase.auth.getSession();
-    setSessionInfo(data.session?.user ?? null);
-    return data.session;
+    setStatus("Session already exists");
+    setSessionInfo(session.user);
+    return session;
   }
 
   async function testInsertDrink() {

--- a/components/DrinkPicker/DrinkPicker.tsx
+++ b/components/DrinkPicker/DrinkPicker.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/sheet";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useDrinkPicker } from "./hooks/useDrinkPicker";
 import { DrinkList } from "@/components/DrinkPicker/DrinkList";
@@ -19,6 +19,7 @@ import { useFavorites } from "./hooks/useFavorites";
 import { useRecents } from "./hooks/useRecents";
 import React from "react";
 import { supabase } from "@/lib/supabaseClient";
+import { useAnonSession } from "@/hooks/useAnonSession";
 import { toast } from "react-hot-toast";
 
 interface DrinkPickerProps {
@@ -40,29 +41,7 @@ export function DrinkPicker({
   const { recents, addRecent } = useRecents();
 
   // Ensure anonymous session
-  useEffect(() => {
-    async function ensureAnonymousSession() {
-      try {
-        const { data, error } = await supabase.auth.getSession();
-        if (error) {
-          console.error("Error getting session:", error);
-          return;
-        }
-
-        if (!data.session) {
-          const { error: signInError } =
-            await supabase.auth.signInAnonymously();
-          if (signInError) {
-            console.error("Error signing in anonymously:", signInError);
-          }
-        }
-      } catch (err) {
-        console.error("Session initialization error:", err);
-      }
-    }
-
-    ensureAnonymousSession();
-  }, []);
+  useAnonSession();
 
   // Focus handling
   const inputRef = React.useRef<HTMLInputElement>(null);

--- a/components/DrinkPicker/DrinkQuantitySheet.tsx
+++ b/components/DrinkPicker/DrinkQuantitySheet.tsx
@@ -8,8 +8,9 @@ import {
 } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { Drink } from "./types";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { supabase } from "@/lib/supabaseClient";
+import { useAnonSession } from "@/hooks/useAnonSession";
 import { useRecents } from "@/components/DrinkPicker/hooks/useRecents";
 
 interface DrinkQuantitySheetProps {
@@ -29,16 +30,7 @@ export function DrinkQuantitySheet({
   const { addRecent } = useRecents();
 
   // Ensure anonymous session
-  useEffect(() => {
-    async function ensureAnonymousSession() {
-      const { data } = await supabase.auth.getSession();
-      if (!data.session) {
-        await supabase.auth.signInAnonymously();
-      }
-    }
-
-    ensureAnonymousSession();
-  }, []);
+  useAnonSession();
 
   const handleSave = async () => {
     // Get current user session

--- a/migrations/CHANGES_SUMMARY.md
+++ b/migrations/CHANGES_SUMMARY.md
@@ -60,3 +60,9 @@ Created `README_MIGRATION.md` with instructions on how to apply the migration an
 1. Apply the SQL migration in the Supabase SQL editor
 2. Test the application to ensure everything works correctly
 3. Consider updating any other components that might still reference `user_name` or the `users` table
+
+### 4. Hardened `recents` Table
+
+- Added `harden_recents.sql` to convert `recents` identifiers to UUID and enforce foreign keys.
+- Updated RLS policies in both the new migration and `create_recents_table.sql` to restrict access to the current authenticated user.
+- Removed obsolete `alter_consumption.sql` migration.

--- a/migrations/alter_consumption.sql
+++ b/migrations/alter_consumption.sql
@@ -1,2 +1,0 @@
--- Alter the consumption table to make user_name nullable
-ALTER TABLE IF EXISTS public.consumption ALTER COLUMN user_name DROP NOT NULL; 

--- a/migrations/create_recents_table.sql
+++ b/migrations/create_recents_table.sql
@@ -1,7 +1,7 @@
 -- Create the recents table if it doesn't exist
 CREATE TABLE IF NOT EXISTS public.recents (
-    user_id TEXT NOT NULL,
-    drink_id TEXT NOT NULL,
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    drink_id UUID NOT NULL REFERENCES public.drinks(id) ON DELETE CASCADE,
     last_used TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     PRIMARY KEY (user_id, drink_id)
 );
@@ -12,22 +12,22 @@ ALTER TABLE public.recents ENABLE ROW LEVEL SECURITY;
 -- Create policy to allow users to read their own recents
 CREATE POLICY "Users can read their own recents" ON public.recents
     FOR SELECT
-    USING (true);
+    USING (user_id = auth.uid());
 
 -- Create policy to allow users to insert their own recents
 CREATE POLICY "Users can insert their own recents" ON public.recents
     FOR INSERT
-    WITH CHECK (true);
+    WITH CHECK (user_id = auth.uid());
 
 -- Create policy to allow users to update their own recents
 CREATE POLICY "Users can update their own recents" ON public.recents
     FOR UPDATE
-    USING (true);
+    USING (user_id = auth.uid());
 
 -- Create policy to allow users to delete their own recents
 CREATE POLICY "Users can delete their own recents" ON public.recents
     FOR DELETE
-    USING (true);
+    USING (user_id = auth.uid());
 
 -- Add comment
 COMMENT ON TABLE public.recents IS 'Stores recently used drinks for each user'; 

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -87,6 +87,23 @@ export type Database = {
           display_name?: string;
         };
       };
+      recents: {
+        Row: {
+          user_id: string;
+          drink_id: string;
+          last_used: string;
+        };
+        Insert: {
+          user_id: string;
+          drink_id: string;
+          last_used?: string;
+        };
+        Update: {
+          user_id?: string;
+          drink_id?: string;
+          last_used?: string;
+        };
+      };
     };
   };
 };


### PR DESCRIPTION
## Summary
- rely on Supabase session in the dashboard client
- fetch current profile in dashboard page
- use the `useAnonSession` hook across components
- harden `recents` table and remove obsolete migration
- update Supabase types
- load Inter font via `<link>` to avoid build failures

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68416564c4348322be9e9cc11e945d53