### PR TITLE
Improve username handling

### DIFF
--- a/components/AboutModal.tsx
+++ b/components/AboutModal.tsx
@@ -6,6 +6,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { resetApp } from "@/lib/resetApp";
 
 interface AboutModalProps {
   open: boolean;
@@ -101,6 +102,20 @@ export function AboutModal({ open, onOpenChange }: AboutModalProps) {
                   Servizio Sanitario Nazionale
                 </a>
               </span>
+            </p>
+            <p
+              className="text-center text-xs text-red-600 underline mt-4 cursor-pointer"
+              onClick={() => {
+                if (
+                  confirm(
+                    "Confermando eliminerai l'account e tutti i dati collegati. Procedere?"
+                  )
+                ) {
+                  resetApp();
+                }
+              }}
+            >
+              Elimina account
             </p>
           </div>
         </div>

--- a/components/StatsModal.tsx
+++ b/components/StatsModal.tsx
@@ -8,7 +8,6 @@ import {
 } from "@/components/ui/dialog";
 import { Card, CardContent } from "@/components/ui/card";
 import { motion } from "framer-motion";
-import { resetApp } from "@/lib/resetApp";
 
 interface StatsData {
   dailyUnits: number;
@@ -166,12 +165,6 @@ export function StatsModal({
             Nazionale. Non superare le 14 unità a settimana distribuite su
             almeno 3 giorni
           </p>
-          <button
-            onClick={resetApp}
-            className="mt-3 text-xs text-red-600 underline"
-          >
-            Reset app
-          </button>
         </div>
       </DialogContent>
     </Dialog>

--- a/components/UserSelect.tsx
+++ b/components/UserSelect.tsx
@@ -46,6 +46,31 @@ export default function UserSelect() {
   // Initialize anonymous session
   useAnonSession();
 
+  // If a profile exists for the current session, skip selection
+  useEffect(() => {
+    const checkProfile = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const userId = session?.user?.id;
+      if (!userId) return;
+
+      const { data } = await supabase
+        .from("profiles")
+        .select("display_name")
+        .eq("id", userId)
+        .single();
+
+      if (data) {
+        localStorage.setItem("currentUserId", userId);
+        localStorage.setItem("currentUserName", data.display_name);
+        router.replace("/dashboard");
+      }
+    };
+
+    checkProfile();
+  }, [router]);
+
   useEffect(() => {
     async function fetchUsers() {
       try {

--- a/migrations/CHANGES_SUMMARY.md
+++ b/migrations/CHANGES_SUMMARY.md
@@ -44,6 +44,14 @@ ALTER TABLE consumption DROP COLUMN IF EXISTS user_name;
 DROP TABLE IF EXISTS users;
 ```
 
+Created `migrations/add_unique_display_name.sql`:
+
+```sql
+-- Ensure unique display names
+create unique index if not exists profiles_display_name_unique
+  on profiles (lower(display_name));
+```
+
 ## Documentation
 
 Created `README_MIGRATION.md` with instructions on how to apply the migration and verify the changes.

--- a/migrations/add_unique_display_name.sql
+++ b/migrations/add_unique_display_name.sql
@@ -1,0 +1,3 @@
+-- Ensure display_name is unique across all profiles (case-insensitive)
+create unique index if not exists profiles_display_name_unique
+  on profiles (lower(display_name));


### PR DESCRIPTION
## Summary
- auto-login if a profile already exists for the current session
- enforce unique usernames via a database migration
- document the new migration in `CHANGES_SUMMARY.md`

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841702c3e0c83228a317a2a722198d7