### PR TITLE
[Feature] Remove drink picker close button

### DIFF
--- a/components/DrinkPicker/DrinkPicker.tsx
+++ b/components/DrinkPicker/DrinkPicker.tsx
@@ -43,16 +43,8 @@ export function DrinkPicker({
   // Ensure anonymous session
   useAnonSession();
 
-  // Focus handling
+  // Input ref for potential focus management
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const handleInputFocus = () => {
-    // Small delay to avoid keyboard popping up during animation
-    setTimeout(() => {
-      if (inputRef.current) {
-        inputRef.current.focus();
-      }
-    }, 500);
-  };
 
   const categories = [
     "Tutti",
@@ -111,6 +103,8 @@ export function DrinkPicker({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="bottom"
+        hideClose
+        onOpenAutoFocus={(e) => e.preventDefault()}
         className="h-[65vh] max-h-[600px] p-0 rounded-t-3xl overflow-hidden bg-white border-0 shadow-2xl"
       >
         <SheetHeader className="sr-only">
@@ -140,12 +134,6 @@ export function DrinkPicker({
                 }}
               />
             </div>
-            <button
-              className="hidden" // Invisible button to trigger keyboard on demand
-              onClick={handleInputFocus}
-            >
-              Focus Input
-            </button>
           </div>
 
           {/* Recent & Favourites chips with improved spacing and icons */}

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -51,12 +51,14 @@ const sheetVariants = cva(
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  hideClose?: boolean
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", className, children, hideClose = false, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
     <SheetPrimitive.Content
@@ -64,10 +66,12 @@ const SheetContent = React.forwardRef<
       className={cn(sheetVariants({ side }), className)}
       {...props}
     >
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
+      {!hideClose && (
+        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      )}
       {children}
     </SheetPrimitive.Content>
   </SheetPortal>


### PR DESCRIPTION
## Summary
- add hideClose flag to SheetContent and use it in DrinkPicker
- prevent DrinkPicker sheet from auto focusing its search input

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68494ccda40c83229c45ba1b84bdff01