### PR TITLE
[Feature] Add Supabase keepalive automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Supabase Configuration (Human will add these to .env.local and Vercel)
+SUPABASE_URL=https://your-project-id.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
+
+# Keepalive Security (Human will generate a random secret)
+KEEPALIVE_SECRET=your_random_secret_string_123

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,41 @@
+name: Keep Supabase Alive
+
+on:
+  schedule:
+    # Run every 3 days at 12:00 UTC (safer than weekly)
+    - cron: '0 12 */3 * *'
+  workflow_dispatch:
+    # Allow manual triggering from GitHub interface
+
+jobs:
+  ping-database:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    
+    steps:
+      - name: Ping keepalive endpoint
+        run: |
+          echo "Sending keepalive request..."
+          response=$(curl -sS -w "\n%{http_code}" "${{ secrets.KEEPALIVE_URL }}" || echo "CURL_FAILED")
+          
+          if [[ "$response" == *"CURL_FAILED"* ]]; then
+            echo "❌ Curl request failed"
+            exit 1
+          fi
+          
+          http_code=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | sed '$d')
+          
+          echo "HTTP Status: $http_code"
+          echo "Response Body: $body"
+          
+          if [[ "$http_code" != "200" ]]; then
+            echo "❌ Keepalive failed with HTTP status: $http_code"
+            exit 1
+          fi
+          
+          echo "✅ Keepalive successful"
+
+      - name: Log completion
+        if: success()
+        run: echo "Database keepalive completed successfully at $(date)"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,54 @@ npm run build
 npm run start
 ```
 
+## Supabase Keepalive Automation
+
+This project includes an automated system to prevent the Supabase database from pausing due to inactivity.
+
+### How It Works
+- GitHub Actions pings the `/api/keepalive` endpoint every 3 days
+- The endpoint performs lightweight database queries to keep Supabase active
+- Runs automatically, no manual intervention needed
+
+### Setup Requirements
+The following environment variables must be configured by the developer:
+
+**In Vercel Dashboard:**
+- `SUPABASE_URL`: Supabase project URL
+- `SUPABASE_SERVICE_ROLE_KEY`: Service role key from Supabase dashboard  
+- `KEEPALIVE_SECRET`: Random secret string for endpoint security
+
+**In GitHub Repository Secrets:**
+- `KEEPALIVE_URL`: Complete URL with secret parameter for the keepalive endpoint
+
+### Testing
+After setup, test the endpoint:
+```bash
+curl "https://your-app.vercel.app/api/keepalive?secret=your_secret"
+```
+
+Expected response:
+```json
+{
+  "ok": true,
+  "timestamp": "2024-06-30T12:00:00.000Z",
+  "tables_checked": ["drinks", "consumption"],
+  "status": "Database connection successful"
+}
+```
+
+### Monitoring
+- Check GitHub Actions tab for automated run status
+- Workflow runs every 3 days at 12:00 UTC
+- Can be triggered manually from GitHub Actions interface
+- Failed runs will appear with error indicators
+
+### Architecture
+- **API Endpoint**: `/app/api/keepalive/route.ts` - Secure endpoint that queries database
+- **GitHub Workflow**: `.github/workflows/keepalive.yml` - Automated scheduler
+- **Security**: Secret parameter prevents unauthorized access
+- **Reliability**: Multiple table queries ensure comprehensive database activity
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/app/api/keepalive/route.ts
+++ b/app/api/keepalive/route.ts
@@ -1,0 +1,39 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextResponse } from 'next/server';
+
+const supabaseAdmin = createClient(
+  process.env.SUPABASE_URL || 'https://placeholder.supabase.co',
+  process.env.SUPABASE_SERVICE_ROLE_KEY || 'placeholder'
+);
+
+export async function GET(request: Request) {
+  // Extract and validate secret parameter
+  const url = new URL(request.url);
+  const secret = url.searchParams.get('secret');
+  
+  if (secret !== process.env.KEEPALIVE_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    // Perform lightweight database queries to keep Supabase alive
+    await Promise.all([
+      supabaseAdmin.from('drinks').select('id').limit(1),
+      supabaseAdmin.from('consumption').select('id').limit(1)
+    ]);
+    
+    return NextResponse.json({ 
+      ok: true, 
+      timestamp: new Date().toISOString(),
+      tables_checked: ['drinks', 'consumption'],
+      status: 'Database connection successful'
+    });
+  } catch (err) {
+    console.error('Keepalive failed:', err);
+    return NextResponse.json({ 
+      ok: false, 
+      error: (err as Error).message,
+      timestamp: new Date().toISOString()
+    }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- create keepalive API route for Supabase pings
- add GitHub Actions workflow to hit endpoint on schedule
- provide `.env.example` with required variables
- document keepalive setup in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862a5f06554832289a6eabb81d032b2